### PR TITLE
Use newer versions AudioContext methods: createScriptProcessor() and createGain()

### DIFF
--- a/build/libs.js
+++ b/build/libs.js
@@ -1802,11 +1802,12 @@ FFT.prototype.forward = function(buffer) {
       this.isLoaded = false;
       this.progress = 0;
 
-      this.proc = this.context.createJavaScriptNode( SAMPLE_SIZE / 2, 1, 1 );
+      this.proc = (this.context.createScriptProcessor || this.context.createJavaScriptNode)( SAMPLE_SIZE / 2, 1, 1 );
       this.proc.onaudioprocess = function ( e ) {
         _this.update.call( _this, e );
       };
-      this.gain = this.context.createGainNode();
+		
+      this.gain = (this.context.createGain || this.context.createGainNode)();
 
       this.fft = new FFT( SAMPLE_SIZE / 2, SAMPLE_RATE );
       this.signal = new Float32Array( SAMPLE_SIZE / 2 );


### PR DESCRIPTION
So that this works in newer browsers that have updated AudioContext APIs.

