### PR TITLE
Minor chrome fixes for examples

### DIFF
--- a/build/webvs.js
+++ b/build/webvs.js
@@ -716,6 +716,7 @@ Webvs.WebAudioAnalyser = Webvs.defineClass(WebAudioAnalyser, Webvs.AnalyserAdapt
             this.source = this.context.createMediaElementSource(element);
         } else {
             element = new Audio();
+            element.crossOrigin = 'anonymous';
             element.src = source;
             this.source = this.context.createMediaElementSource(element);
         }

--- a/examples/common.js
+++ b/examples/common.js
@@ -30,7 +30,7 @@ var SMReady = function () {
     });
 
     // load and play the track
-    var trackUrl = "https://soundcloud.com/gigamesh/fleetwood-mac-dreams-gigamesh";
+    var trackUrl = "https://soundcloud.com/bigsean-1/bounce-back";
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
         if (xhr.readyState == 4 && xhr.status == 200) {


### PR DESCRIPTION
This PR fixes the examples in Chrome.

1) Updates the SoundCloud track URL, as "These Dreams" is no longer available.

2) Adds `element.crossOrigin = "anonymous"` to Audio element so that its stream can be parsed; otherwise the stream comes out as 0s in Chrome (see http://stackoverflow.com/questions/34782046/how-can-i-get-audio-to-play-when-mediaelementaudiosource-outputs-zeroes-but-cor)

