### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{json,ts}]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 root = true
 
 [*.{ts,json,js}]
-end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,9 @@
 root = true
 
-[*]
+[*.{ts,json,js}]
+end_of_line = crlf
 charset = utf-8
-end_of_line = lf
+trim_trailing_whitespace = true
 insert_final_newline = true
-
-[*.{json,ts}]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
It's been my experience that using [EditorConfig](http://editorconfig.org/) is a good idea when there are many contributors, just to make sure we follow the same set of rules without the need to meddle with one's personal editor preferences.