### PR TITLE
Compile invsqrt to webgl inversesqrt

### DIFF
--- a/src/expr/compileExpr.ts
+++ b/src/expr/compileExpr.ts
@@ -379,7 +379,7 @@ function generateGlsl(codeAst: ICodeAst, tables: ISymbolTables, glslFuncs: strin
                 case "bnot":
                     return "(float(!(" + generateNode(ast.args[0]) + ")))";
                 case "invsqrt":
-                    return "(1/sqrt(" + generateNode(ast.args[0]) + "))";
+                    return "(inversesqrt(" + generateNode(ast.args[0]) + "))";
                 case "atan2":
                     return "(atan((" + generateNode(ast.args[0]) + "),(" + generateNode(ast.args[1]) + "))";
                 default: {


### PR DESCRIPTION
WebGL provides a (presumably faster) `inversesqrt()`-function. This commit makes use of that.
I tested it and it produces the same results as in AVS. I cannot say if this is faster, but it might be, given enough occurrences within one preset.